### PR TITLE
Statemachine modifications

### DIFF
--- a/src/StateMachine/Entities/IStateMachineTransitionEffect.cs
+++ b/src/StateMachine/Entities/IStateMachineTransitionEffect.cs
@@ -14,11 +14,11 @@ public interface IStateMachineTransitionEffect
 /// Base abstract class for transition effects with common properties.
 /// The effect type is automatically determined by the implementing class type.
 /// </summary>
-public abstract class StateMachineTransitionEffect : IStateMachineTransitionEffect
+public abstract record StateMachineTransitionEffect : IStateMachineTransitionEffect
 {
-    public string? Description { get; set; }
-    public bool IsOptional { get; set; } = false;
-    public int ExecutionOrder { get; set; } = 0;
+    public string? Description { get; init; }
+    public bool IsOptional { get; init; } = false;
+    public int ExecutionOrder { get; init; } = 0;
 
     /// <summary>
     /// Gets the effect type name based on the actual implementation type.

--- a/src/StateMachine/Entities/IStateMachineTransitionRequirement.cs
+++ b/src/StateMachine/Entities/IStateMachineTransitionRequirement.cs
@@ -14,10 +14,10 @@ public interface IStateMachineTransitionRequirement
 /// Base abstract class for transition requirements with common properties.
 /// The requirement type is automatically determined by the implementing class type.
 /// </summary>
-public abstract class StateMachineTransitionRequirement : IStateMachineTransitionRequirement
+public abstract record StateMachineTransitionRequirement : IStateMachineTransitionRequirement
 {
-    public string? Description { get; set; }
-    public bool IsOptional { get; set; } = false;
+    public string? Description { get; init; }
+    public bool IsOptional { get; init; } = false;
 
     /// <summary>
     /// Gets the requirement type name based on the actual implementation type.

--- a/src/StateMachine/Entities/StateMachineDefinition.cs
+++ b/src/StateMachine/Entities/StateMachineDefinition.cs
@@ -56,62 +56,6 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
 
 
     /// <summary>
-    /// Adds a state to the definition.
-    /// </summary>
-    public void AddState(string stateName, string? description = null, bool isFinal = false)
-    {
-        if (string.IsNullOrWhiteSpace(stateName))
-            throw new ArgumentException("State name cannot be null or empty.", nameof(stateName));
-
-        if (_states.Any(s => s.Name == stateName))
-            throw new InvalidOperationException($"State '{stateName}' already exists.");
-
-        var category = isFinal ? StateMachineStateCategory.Final : StateMachineStateCategory.Intermediate;
-        var state = StateMachineState.Create(Id, stateName, description, category);
-        _states.Add(state);
-    }
-
-    /// <summary>
-    /// Adds a trigger to the definition.
-    /// </summary>
-    public void AddTrigger(string triggerName, string? description = null, StateMachineTriggerType type = StateMachineTriggerType.Manual)
-    {
-        if (string.IsNullOrWhiteSpace(triggerName))
-            throw new ArgumentException("Trigger name cannot be null or empty.", nameof(triggerName));
-
-        if (_triggers.Any(t => t.Name == triggerName))
-            throw new InvalidOperationException($"Trigger '{triggerName}' already exists.");
-
-        var trigger = StateMachineTrigger.Create(Id, triggerName, description, type);
-        _triggers.Add(trigger);
-    }
-
-    /// <summary>
-    /// Adds a transition to the definition.
-    /// </summary>
-    public void AddTransition(StateMachineState fromState, StateMachineState toState, StateMachineTrigger trigger)
-    {
-        var transition = StateMachineTransition.Create(Id, fromState, toState, trigger);
-        _transitions.Add(transition);
-    }
-
-    /// <summary>
-    /// Adds a transition to the definition with requirements.
-    /// </summary>
-    public void AddTransition(
-        StateMachineState fromState,
-        StateMachineState toState,
-        StateMachineTrigger trigger,
-        IEnumerable<IStateMachineTransitionRequirement>? requirements = null,
-        string? description = null)
-    {
-        var transition = StateMachineTransition.Create(Id, fromState, toState, trigger, description, requirements);
-        _transitions.Add(transition);
-    }
-
-
-
-    /// <summary>
     /// Creates a new version of this definition.
     /// </summary>
     public abstract StateMachineDefinition CreateNewVersion();
@@ -127,24 +71,45 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
         // Copy all states except the initial state (which is already created in constructor)
         foreach (var state in _states.Where(s => s.Id != InitialState.Id))
         {
-            newDefinition.AddState(state.Name, state.Description, state.Category == StateMachineStateCategory.Final);
+            var newState = StateMachineState.Create(
+                newDefinition.Id, 
+                state.Name, 
+                state.Description, 
+                state.Category);
+            newDefinition._states.Add(newState);
         }
 
         // Copy all triggers
         foreach (var trigger in _triggers)
         {
-            newDefinition.AddTrigger(trigger.Name, trigger.Description, trigger.Type);
+            var newTrigger = StateMachineTrigger.Create(
+                newDefinition.Id, 
+                trigger.Name, 
+                trigger.Description, 
+                trigger.Type);
+            newDefinition._triggers.Add(newTrigger);
         }
 
         // Copy all transitions with their requirements and descriptions
         foreach (var transition in _transitions)
         {
-            newDefinition.AddTransition(
-                transition.FromState,
-                transition.ToState,
-                transition.Trigger,
-                transition.Requirements,
-                transition.Description);
+            // Find the corresponding states and triggers in the new definition
+            var newFromState = newDefinition._states.FirstOrDefault(s => s.Name == transition.FromState.Name);
+            var newToState = newDefinition._states.FirstOrDefault(s => s.Name == transition.ToState.Name);
+            var newTrigger = newDefinition._triggers.FirstOrDefault(t => t.Name == transition.Trigger.Name);
+
+            if (newFromState != null && newToState != null && newTrigger != null)
+            {
+                var newTransition = StateMachineTransition.Create(
+                    newDefinition.Id,
+                    newFromState,
+                    newToState,
+                    newTrigger,
+                    transition.Description,
+                    transition.Requirements,
+                    transition.Effects);
+                newDefinition._transitions.Add(newTransition);
+            }
         }
     }
 

--- a/src/StateMachine/Entities/StateMachineDefinition.cs
+++ b/src/StateMachine/Entities/StateMachineDefinition.cs
@@ -94,11 +94,15 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
         foreach (var transition in _transitions)
         {
             // Find the corresponding states and triggers in the new definition
-            var newFromState = newDefinition._states.FirstOrDefault(s => s.Name == transition.FromState.Name);
-            var newToState = newDefinition._states.FirstOrDefault(s => s.Name == transition.ToState.Name);
+            var newFromState = transition.FromState != null 
+                ? newDefinition._states.FirstOrDefault(s => s.Name == transition.FromState.Name)
+                : null;
+            var newToState = transition.ToState != null 
+                ? newDefinition._states.FirstOrDefault(s => s.Name == transition.ToState.Name)
+                : null;
             var newTrigger = newDefinition._triggers.FirstOrDefault(t => t.Name == transition.Trigger.Name);
 
-            if (newFromState != null && newToState != null && newTrigger != null)
+            if (newTrigger != null)
             {
                 var newTransition = StateMachineTransition.Create(
                     newDefinition.Id,
@@ -158,8 +162,12 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
         // Add all transitions with their triggers
         foreach (var transition in _transitions)
         {
-            var fromStateName = SanitizeStateName(transition.FromState.Name);
-            var toStateName = SanitizeStateName(transition.ToState.Name);
+            var fromStateName = transition.FromState != null 
+                ? SanitizeStateName(transition.FromState.Name)
+                : "[*]";
+            var toStateName = transition.ToState != null 
+                ? SanitizeStateName(transition.ToState.Name)
+                : "[*]";
             var triggerName = transition.Trigger.Name;
 
             diagram.AppendLine($"    {fromStateName} --> {toStateName} : {triggerName}");
@@ -274,7 +282,8 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
 
         foreach (var transition in _transitions)
         {
-            reachableStates.Add(transition.ToStateId);
+            if (transition.ToStateId.HasValue)
+                reachableStates.Add(transition.ToStateId.Value);
         }
 
         var orphanedStates = InitialState != null

--- a/src/StateMachine/Entities/StateMachineDefinition.cs
+++ b/src/StateMachine/Entities/StateMachineDefinition.cs
@@ -42,7 +42,6 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
 
     protected StateMachineDefinition(
         string initialStateName,
-        Guid createdBy,
         int version = 1)
     {
         Version = version;
@@ -115,7 +114,7 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
     /// <summary>
     /// Creates a new version of this definition.
     /// </summary>
-    public abstract StateMachineDefinition CreateNewVersion(Guid createdBy);
+    public abstract StateMachineDefinition CreateNewVersion();
 
     /// <summary>
     /// Helper method to copy states, triggers, and transitions to a new definition.
@@ -394,9 +393,8 @@ public class StateMachineDefinition<TEntity> : StateMachineDefinition where TEnt
     protected StateMachineDefinition(
         TEntity entity,
         string initialStateName,
-        Guid createdBy,
         int version = 1)
-        : base(initialStateName, createdBy, version)
+        : base(initialStateName, version)
     {
         Entity = entity;
         EntityId = entity.Id;
@@ -413,12 +411,12 @@ public class StateMachineDefinition<TEntity> : StateMachineDefinition where TEnt
     /// <summary>
     /// Creates a new version of this definition.
     /// </summary>
-    public override StateMachineDefinition CreateNewVersion(Guid createdBy)
+    public override StateMachineDefinition CreateNewVersion()
     {
         if (InitialState == null)
             throw new InvalidOperationException("Cannot create new version without an initial state.");
 
-        var newDefinition = new StateMachineDefinition<TEntity>(Entity, InitialState.Name, createdBy, Version + 1);
+        var newDefinition = new StateMachineDefinition<TEntity>(Entity, InitialState.Name, Version + 1);
         newDefinition.SetEntity(Entity);
 
         CopyDefinitionDataTo(newDefinition);

--- a/src/StateMachine/Entities/StateMachineDefinition.cs
+++ b/src/StateMachine/Entities/StateMachineDefinition.cs
@@ -72,9 +72,9 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
         foreach (var state in _states.Where(s => s.Id != InitialState.Id))
         {
             var newState = StateMachineState.Create(
-                newDefinition.Id, 
-                state.Name, 
-                state.Description, 
+                newDefinition.Id,
+                state.Name,
+                state.Description,
                 state.Category);
             newDefinition._states.Add(newState);
         }
@@ -83,9 +83,9 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
         foreach (var trigger in _triggers)
         {
             var newTrigger = StateMachineTrigger.Create(
-                newDefinition.Id, 
-                trigger.Name, 
-                trigger.Description, 
+                newDefinition.Id,
+                trigger.Name,
+                trigger.Description,
                 trigger.Type);
             newDefinition._triggers.Add(newTrigger);
         }
@@ -94,10 +94,10 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
         foreach (var transition in _transitions)
         {
             // Find the corresponding states and triggers in the new definition
-            var newFromState = transition.FromState != null 
+            var newFromState = transition.FromState != null
                 ? newDefinition._states.FirstOrDefault(s => s.Name == transition.FromState.Name)
                 : null;
-            var newToState = transition.ToState != null 
+            var newToState = transition.ToState != null
                 ? newDefinition._states.FirstOrDefault(s => s.Name == transition.ToState.Name)
                 : null;
             var newTrigger = newDefinition._triggers.FirstOrDefault(t => t.Name == transition.Trigger.Name);
@@ -162,10 +162,10 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
         // Add all transitions with their triggers
         foreach (var transition in _transitions)
         {
-            var fromStateName = transition.FromState != null 
+            var fromStateName = transition.FromState != null
                 ? SanitizeStateName(transition.FromState.Name)
                 : "[*]";
-            var toStateName = transition.ToState != null 
+            var toStateName = transition.ToState != null
                 ? SanitizeStateName(transition.ToState.Name)
                 : "[*]";
             var triggerName = transition.Trigger.Name;

--- a/src/StateMachine/Entities/StateMachineDefinition.cs
+++ b/src/StateMachine/Entities/StateMachineDefinition.cs
@@ -58,7 +58,7 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
     /// <summary>
     /// Creates a new version of this definition.
     /// </summary>
-    public abstract StateMachineDefinition CreateNewVersion();
+    public abstract StateMachineDefinition CreateNewVersion(int version);
 
     /// <summary>
     /// Helper method to copy states, triggers, and transitions to a new definition.
@@ -305,50 +305,6 @@ public abstract class StateMachineDefinition : Entity, IHasStatus<StateMachineDe
         return errors;
     }
 
-    /// <summary>
-    /// Removes a state from the definition (if not referenced by any transitions).
-    /// </summary>
-    public void RemoveState(StateMachineState state)
-    {
-        if (state == null)
-            return;
-
-        if (InitialState?.Id == state.Id)
-            throw new InvalidOperationException("Cannot remove the initial state.");
-
-        if (_transitions.Any(t => t.FromStateId == state.Id || t.ToStateId == state.Id))
-            throw new InvalidOperationException($"Cannot remove state '{state.Name}' because it is referenced by transitions.");
-
-        _states.RemoveAll(s => s.Id == state.Id);
-    }
-
-    /// <summary>
-    /// Removes a trigger from the definition (if not referenced by any transitions).
-    /// </summary>
-    public void RemoveTrigger(StateMachineTrigger trigger)
-    {
-        if (trigger == null)
-            return;
-
-        if (_transitions.Any(t => t.TriggerId == trigger.Id))
-            throw new InvalidOperationException($"Cannot remove trigger '{trigger.Name}' because it is referenced by transitions.");
-
-        _triggers.RemoveAll(t => t.Id == trigger.Id);
-    }
-
-    /// <summary>
-    /// Removes a transition from the definition.
-    /// </summary>
-    public void RemoveTransition(StateMachineState fromState, StateMachineState toState, StateMachineTrigger trigger)
-    {
-        if (fromState == null || toState == null || trigger == null)
-            return;
-
-        _transitions.RemoveAll(t => t.FromStateId == fromState.Id &&
-                                   t.ToStateId == toState.Id &&
-                                   t.TriggerId == trigger.Id);
-    }
-
     public void SetStatus(StateMachineDefinitionStatus status)
     {
         Status = status;
@@ -385,12 +341,12 @@ public class StateMachineDefinition<TEntity> : StateMachineDefinition where TEnt
     /// <summary>
     /// Creates a new version of this definition.
     /// </summary>
-    public override StateMachineDefinition CreateNewVersion()
+    public override StateMachineDefinition CreateNewVersion(int version)
     {
         if (InitialState == null)
             throw new InvalidOperationException("Cannot create new version without an initial state.");
 
-        var newDefinition = new StateMachineDefinition<TEntity>(Entity, InitialState.Name, Version + 1);
+        var newDefinition = new StateMachineDefinition<TEntity>(Entity, InitialState.Name, version);
         newDefinition.SetEntity(Entity);
 
         CopyDefinitionDataTo(newDefinition);

--- a/src/StateMachine/Entities/StateMachineInstance.cs
+++ b/src/StateMachine/Entities/StateMachineInstance.cs
@@ -51,14 +51,14 @@ public abstract class StateMachineInstance : Entity
         where TUserId : IEquatable<TUserId>
     {
         var previousState = CurrentState;
-        
+
         // Only change state if this is a state-changing transition
         if (transition.ChangesState)
         {
             CurrentStateId = transition.ToStateId!.Value;
             CurrentState = transition.ToState!;
         }
-        
+
         LastTransitionAt = DateTimeOffset.UtcNow;
 
         // Record transition history
@@ -86,7 +86,7 @@ public abstract class StateMachineInstance : Entity
         _transitionHistory.Add(historyEntry);
 
         // Raise domain events
-        
+
     }
 
     /// <summary>
@@ -119,7 +119,7 @@ public abstract class StateMachineInstance : Entity
         _transitionHistory.Add(historyEntry);
 
         // Raise domain event for forced transition
-        
+
     }
 
     /// <summary>

--- a/src/StateMachine/Entities/StateMachineInstance.cs
+++ b/src/StateMachine/Entities/StateMachineInstance.cs
@@ -51,8 +51,14 @@ public abstract class StateMachineInstance : Entity
         where TUserId : IEquatable<TUserId>
     {
         var previousState = CurrentState;
-        CurrentStateId = transition.ToStateId;
-        CurrentState = transition.ToState;
+        
+        // Only change state if this is a state-changing transition
+        if (transition.ChangesState)
+        {
+            CurrentStateId = transition.ToStateId!.Value;
+            CurrentState = transition.ToState!;
+        }
+        
         LastTransitionAt = DateTimeOffset.UtcNow;
 
         // Record transition history
@@ -63,7 +69,7 @@ public abstract class StateMachineInstance : Entity
             historyEntry = StateMachineStateTransitionHistory<TUser, TUserId>.CreateForced(
                 Id,
                 previousState,
-                CurrentState,
+                transition.ToState ?? CurrentState,
                 reason ?? "Forced transition",
                 triggeredBy);
         }
@@ -72,7 +78,7 @@ public abstract class StateMachineInstance : Entity
             historyEntry = StateMachineStateTransitionHistory<TUser, TUserId>.Create(
                 Id,
                 previousState,
-                CurrentState,
+                transition.ToState ?? CurrentState,
                 transition.Trigger,
                 triggeredBy);
         }

--- a/src/StateMachine/Entities/StateMachineTransition.cs
+++ b/src/StateMachine/Entities/StateMachineTransition.cs
@@ -8,10 +8,10 @@ namespace AQ.StateMachineEntities;
 public class StateMachineTransition : Entity
 {
     public Guid StateMachineDefinitionId { get; private set; }
-    public StateMachineState FromState { get; private set; } = default!;
-    public Guid FromStateId { get; private set; }
-    public StateMachineState ToState { get; private set; } = default!;
-    public Guid ToStateId { get; private set; }
+    public StateMachineState? FromState { get; private set; }
+    public Guid? FromStateId { get; private set; }
+    public StateMachineState? ToState { get; private set; }
+    public Guid? ToStateId { get; private set; }
     public StateMachineTrigger Trigger { get; private set; } = default!;
     public Guid TriggerId { get; private set; }
     public string? Description { get; private set; }
@@ -24,18 +24,18 @@ public class StateMachineTransition : Entity
 
     private StateMachineTransition(
         Guid stateMachineDefinitionId,
-        StateMachineState fromState,
-        StateMachineState toState,
+        StateMachineState? fromState,
+        StateMachineState? toState,
         StateMachineTrigger trigger,
         string? description = null,
         IEnumerable<IStateMachineTransitionRequirement>? requirements = null,
         IEnumerable<IStateMachineTransitionEffect>? effects = null)
     {
         StateMachineDefinitionId = stateMachineDefinitionId;
-        FromState = fromState ?? throw new ArgumentNullException(nameof(fromState));
-        FromStateId = fromState.Id;
-        ToState = toState ?? throw new ArgumentNullException(nameof(toState));
-        ToStateId = toState.Id;
+        FromState = fromState;
+        FromStateId = fromState?.Id;
+        ToState = toState;
+        ToStateId = toState?.Id;
         Trigger = trigger ?? throw new ArgumentNullException(nameof(trigger));
         TriggerId = trigger.Id;
         Description = description?.Trim();
@@ -48,19 +48,13 @@ public class StateMachineTransition : Entity
     /// </summary>
     public static StateMachineTransition Create(
         Guid stateMachineDefinitionId,
-        StateMachineState fromState,
-        StateMachineState toState,
+        StateMachineState? fromState,
+        StateMachineState? toState,
         StateMachineTrigger trigger,
         string? description = null,
         IEnumerable<IStateMachineTransitionRequirement>? requirements = null,
         IEnumerable<IStateMachineTransitionEffect>? effects = null)
     {
-        if (fromState == null)
-            throw new ArgumentNullException(nameof(fromState));
-
-        if (toState == null)
-            throw new ArgumentNullException(nameof(toState));
-
         if (trigger == null)
             throw new ArgumentNullException(nameof(trigger));
 
@@ -106,6 +100,16 @@ public class StateMachineTransition : Entity
     /// Gets the count of effects for this transition.
     /// </summary>
     public int EffectCount => Effects?.Count() ?? 0;
+
+    /// <summary>
+    /// Indicates whether this transition changes state (has both from and to states).
+    /// </summary>
+    public bool ChangesState => FromState != null && ToState != null;
+
+    /// <summary>
+    /// Indicates whether this is a trigger-only transition (no state change).
+    /// </summary>
+    public bool IsTriggerOnly => FromState == null || ToState == null;
 
     /// <summary>
     /// Adds a requirement to this transition.
@@ -179,5 +183,8 @@ public class StateMachineTransition : Entity
         Effects = currentEffects.Any() ? currentEffects : null;
     }
 
-    public override string ToString() => $"{FromState.Name} -> {ToState.Name} ({Trigger.Name})";
+    public override string ToString() =>
+        ChangesState
+            ? $"{FromState!.Name} -> {ToState!.Name} ({Trigger.Name})"
+            : $"Trigger: {Trigger.Name}";
 }

--- a/src/StateMachine/Services/IStateMachineTransitionService.cs
+++ b/src/StateMachine/Services/IStateMachineTransitionService.cs
@@ -122,8 +122,8 @@ public class AvailableTransition
 {
     public Guid TriggerId { get; set; }
     public string TriggerName { get; set; } = default!;
-    public Guid ToStateId { get; set; }
-    public string ToStateName { get; set; } = default!;
+    public Guid? ToStateId { get; set; }
+    public string? ToStateName { get; set; }
     public Guid TransitionId { get; set; }
     public bool CanExecute { get; set; }
     public RequirementEvaluationSummary? RequirementEvaluation { get; set; }

--- a/src/StateMachine/Services/StateMachineEffectExecutionService.cs
+++ b/src/StateMachine/Services/StateMachineEffectExecutionService.cs
@@ -1,6 +1,6 @@
-﻿using System.Diagnostics;
+﻿using AQ.StateMachineEntities;
+using System.Diagnostics;
 using System.Reflection;
-using AQ.StateMachineEntities;
 
 namespace AQ.StateMachine.Services;
 

--- a/src/StateMachine/Services/StateMachineRequirementEvaluationService.cs
+++ b/src/StateMachine/Services/StateMachineRequirementEvaluationService.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using AQ.StateMachineEntities;
+﻿using AQ.StateMachineEntities;
+using System.Reflection;
 
 namespace AQ.StateMachine.Services;
 

--- a/src/StateMachine/Services/StateMachineTransitionServiceBase.cs
+++ b/src/StateMachine/Services/StateMachineTransitionServiceBase.cs
@@ -31,8 +31,10 @@ public abstract class StateMachineTransitionServiceBase : IStateMachineTransitio
         where TUserId : IEquatable<TUserId>
     {
         // 1. Find available transitions for the trigger
+        // Include both state-changing transitions and trigger-only transitions
         var availableTransitions = stateMachine.Definition.Transitions
-            .Where(t => t.FromStateId == stateMachine.CurrentStateId && t.Trigger.Id == trigger.Id)
+            .Where(t => t.Trigger.Id == trigger.Id &&
+                       (t.FromStateId == stateMachine.CurrentStateId || t.FromStateId == null))
             .ToList();
 
         if (!availableTransitions.Any())
@@ -156,8 +158,9 @@ public abstract class StateMachineTransitionServiceBase : IStateMachineTransitio
     {
         var availableTransitions = new List<AvailableTransition>();
 
+        // Include both state-changing transitions and trigger-only transitions
         var transitionsFromCurrentState = stateMachine.Definition.Transitions
-            .Where(t => t.FromStateId == stateMachine.CurrentStateId);
+            .Where(t => t.FromStateId == stateMachine.CurrentStateId || t.FromStateId == null);
 
         foreach (var transition in transitionsFromCurrentState)
         {
@@ -167,8 +170,8 @@ public abstract class StateMachineTransitionServiceBase : IStateMachineTransitio
             {
                 TriggerId = transition.Trigger.Id,
                 TriggerName = transition.Trigger.Name,
-                ToStateId = transition.ToState.Id,
-                ToStateName = transition.ToState.Name,
+                ToStateId = transition.ToState?.Id,
+                ToStateName = transition.ToState?.Name,
                 TransitionId = transition.Id,
                 CanExecute = evaluationResult.IsSuccess && evaluationResult.Value.AllRequirementsMet,
                 RequirementEvaluation = evaluationResult.IsSuccess ? evaluationResult.Value : null

--- a/src/ValueObjects/AQ.ValueObjects.csproj
+++ b/src/ValueObjects/AQ.ValueObjects.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Markdig"  PrivateAssets="All"/>
-    <PackageReference Include="HtmlSanitizer"  PrivateAssets="All"/>
+    <PackageReference Include="Markdig"  />
+    <PackageReference Include="HtmlSanitizer"  />
   </ItemGroup>
 </Project>

--- a/src/ValueObjects/DataCollection/CollectedValue.cs
+++ b/src/ValueObjects/DataCollection/CollectedValue.cs
@@ -1,5 +1,9 @@
-﻿namespace AQ.ValueObjects.DataCollection;
+﻿using System.Text.Json.Serialization;
 
+namespace AQ.ValueObjects.DataCollection;
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+[JsonDerivedType(typeof(CollectedValue), typeDiscriminator: "collectedValue")]
 public class CollectedValue : ValueObject
 {
     public DataType DataType { get; private set; }

--- a/src/ValueObjects/DataCollection/DataType.cs
+++ b/src/ValueObjects/DataCollection/DataType.cs
@@ -1,5 +1,8 @@
-﻿namespace AQ.ValueObjects.DataCollection;
+﻿using System.Text.Json.Serialization;
 
+namespace AQ.ValueObjects.DataCollection;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum DataType
 {
     String,

--- a/src/ValueObjects/DataCollection/FieldDefinition.cs
+++ b/src/ValueObjects/DataCollection/FieldDefinition.cs
@@ -1,5 +1,9 @@
-﻿namespace AQ.ValueObjects.DataCollection;
+﻿using System.Text.Json.Serialization;
 
+namespace AQ.ValueObjects.DataCollection;
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+[JsonDerivedType(typeof(FieldDefinition), typeDiscriminator: "fieldDefinition")]
 public class FieldDefinition : ValueObject
 {
     public string Name { get; private set; } = default!;

--- a/src/ValueObjects/Email.cs
+++ b/src/ValueObjects/Email.cs
@@ -1,5 +1,4 @@
-﻿using AQ.ValueObjects;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace AQ.ValueObjects;
 

--- a/src/ValueObjects/MarkdownContent.cs
+++ b/src/ValueObjects/MarkdownContent.cs
@@ -85,4 +85,9 @@ public sealed class MarkdownContent : ValueObject
         yield return Value;
         yield return Html;
     }
+
+    public MarkdownContent Clone()
+    {
+        return Create(this.Value);
+    }
 }


### PR DESCRIPTION
This pull request introduces several significant changes to the state machine entity and service classes, primarily to support transitions that may not require both a source and destination state ("trigger-only" transitions). It also refactors some base classes and improves the handling of state transitions and versioning. The most important changes are grouped below:

### Support for Trigger-Only Transitions

* Updated the `StateMachineTransition` class so that `FromState` and `ToState` are now nullable, allowing transitions that do not require both a source and destination state. This includes changes to constructors, properties, and the `Create` method, as well as new properties `ChangesState` and `IsTriggerOnly` to distinguish between state-changing and trigger-only transitions. The `ToString()` method was also updated for clarity. [[1]](diffhunk://#diff-1fc86cffcfce4bb78d986fccb906807ce093421607808a1930adb0fa41570b2fL11-R14) [[2]](diffhunk://#diff-1fc86cffcfce4bb78d986fccb906807ce093421607808a1930adb0fa41570b2fL27-R38) [[3]](diffhunk://#diff-1fc86cffcfce4bb78d986fccb906807ce093421607808a1930adb0fa41570b2fL51-L63) [[4]](diffhunk://#diff-1fc86cffcfce4bb78d986fccb906807ce093421607808a1930adb0fa41570b2fR104-R113) [[5]](diffhunk://#diff-1fc86cffcfce4bb78d986fccb906807ce093421607808a1930adb0fa41570b2fL182-R189)
* Adjusted the `AvailableTransition` class to allow `ToStateId` and `ToStateName` to be nullable, reflecting the possibility of trigger-only transitions.
* Modified transition selection logic in `StateMachineTransitionServiceBase` to include both state-changing and trigger-only transitions when finding available transitions for a trigger.

### Refactoring State Machine Definition and Instance

* Removed several state, trigger, and transition management methods (`AddState`, `AddTrigger`, `AddTransition`, and all `Remove*` methods) from `StateMachineDefinition`, moving to direct manipulation of internal collections for states, triggers, and transitions. This change also affects how copying and versioning of definitions is handled. [[1]](diffhunk://#diff-0c4625289c0aa6b8776ad66e54b9caca14fae5ebdf6abddf35d5911479e4e377L59-R61) [[2]](diffhunk://#diff-0c4625289c0aa6b8776ad66e54b9caca14fae5ebdf6abddf35d5911479e4e377L131-R116) [[3]](diffhunk://#diff-0c4625289c0aa6b8776ad66e54b9caca14fae5ebdf6abddf35d5911479e4e377L335-L378)
* Updated the versioning mechanism for state machine definitions: constructors and `CreateNewVersion` now use an `int version` parameter instead of a `Guid createdBy`, simplifying version tracking. [[1]](diffhunk://#diff-0c4625289c0aa6b8776ad66e54b9caca14fae5ebdf6abddf35d5911479e4e377L45) [[2]](diffhunk://#diff-0c4625289c0aa6b8776ad66e54b9caca14fae5ebdf6abddf35d5911479e4e377L397-R327) [[3]](diffhunk://#diff-0c4625289c0aa6b8776ad66e54b9caca14fae5ebdf6abddf35d5911479e4e377L416-R349)

### Improved Transition Execution Logic

* In `StateMachineInstance`, transition execution now only updates the current state if the transition actually changes state (`ChangesState`), ensuring correct behavior for trigger-only transitions. History recording logic was also updated to use the correct state references. [[1]](diffhunk://#diff-c3d4cf97dcabca316430001b428e147599797ffab67362b796fd1f15bb6d6690L54-R61) [[2]](diffhunk://#diff-c3d4cf97dcabca316430001b428e147599797ffab67362b796fd1f15bb6d6690L66-R72) [[3]](diffhunk://#diff-c3d4cf97dcabca316430001b428e147599797ffab67362b796fd1f15bb6d6690L75-R81)

### General Codebase Improvements

* Refactored base classes for transition requirements and effects to use `record` types and immutable properties, improving code safety and clarity. [[1]](diffhunk://#diff-3325dd08afa1710ca1022dec61d73b09e4443ae9a83ffb00bab10caa68f9360bL17-R21) [[2]](diffhunk://#diff-402a53079a4652d5f79885a5ce4a56610499510783b76d33c0d4a0e09a35040eL17-R20)
* Minor improvements to file imports and ordering for consistency. [[1]](diffhunk://#diff-5176d1c5bef0654ff31f2b940d00cd2181b5afc5c4a54361b95594dc7cc538c4L1-L3) [[2]](diffhunk://#diff-e8833af534a8bf584a7d540d70540b3e88607c37fe72a7b54c7352f0ca2df760L1-R2)

### Other Fixes and Enhancements

* Improved diagram generation and validation logic to handle transitions with nullable states, preventing errors when visualizing or validating state machines with trigger-only transitions. [[1]](diffhunk://#diff-0c4625289c0aa6b8776ad66e54b9caca14fae5ebdf6abddf35d5911479e4e377L197-R170) [[2]](diffhunk://#diff-0c4625289c0aa6b8776ad66e54b9caca14fae5ebdf6abddf35d5911479e4e377L313-R286)

Let me know if you'd like to dive deeper into any of these changes or discuss how they affect your work with the state machine code!