### PR TITLE
Refactor hierarchical entity interfaces and classes

### DIFF
--- a/src/Abstractions/IHierarchicalEntity.cs
+++ b/src/Abstractions/IHierarchicalEntity.cs
@@ -3,5 +3,4 @@ namespace AQ.Abstractions;
 public interface IHierarchicalEntity : IEntity
 {
     Guid? ParentId { get; }
-    int Level { get; }
 }

--- a/src/Abstractions/IHierarchicalEntityClosure.cs
+++ b/src/Abstractions/IHierarchicalEntityClosure.cs
@@ -4,5 +4,4 @@ public interface IHierarchicalEntityClosure
 {
     Guid AncestorId { get; set; }
     Guid DescendantId { get; set; }
-    int Depth { get; set; }
 }

--- a/src/Abstractions/IHierarchyService.cs
+++ b/src/Abstractions/IHierarchyService.cs
@@ -6,4 +6,6 @@ public interface IHierarchyService<T> where T : IHierarchicalEntity
 
     Task<bool> CircularReferenceExists(T entity, Guid? newParentId);
 
+    Task<bool> IsDescendantAsync(T entity, Guid ancestorId);
+    Task<bool> IsAncestorAsync(T entity, Guid descendantId);
 }

--- a/src/Entities/HierarchicalEntity.cs
+++ b/src/Entities/HierarchicalEntity.cs
@@ -11,7 +11,6 @@ namespace AQ.Entities;
 /// <typeparam name="T">The concrete entity type implementing the hierarchy</typeparam>
 public abstract class HierarchicalEntity<T> : Entity, IHierarchicalEntity where T : HierarchicalEntity<T>
 {
-    public int Level { get; protected set; }
 
     // Self-referential for n-level hierarchy
     public Guid? ParentId { get; protected set; }
@@ -32,11 +31,9 @@ public abstract class HierarchicalEntity<T> : Entity, IHierarchicalEntity where 
 
     public async Task SetParent(T? parent, Func<T, Guid?, Task> updateClosure)
     {
-        await updateClosure.Invoke((T)this, parent?.Id);
-
         Parent = parent;
         ParentId = parent?.Id;
-        Level = parent is null ? 0 : parent.Level + 1;
+        await updateClosure.Invoke((T)this, parent?.Id);
     }
 
 }

--- a/src/Entities/HierarchicalEntityClosure.cs
+++ b/src/Entities/HierarchicalEntityClosure.cs
@@ -15,8 +15,6 @@ public abstract class HierarchicalEntityClosure<T> : IHierarchicalEntityClosure 
 
     public Guid DescendantId { get; set; }
     public T Descendant { get; set; } = default!;
-    public int Depth { get; set; }
-
     protected HierarchicalEntityClosure() { }
     // Use this entity for ancestor/descendant mapping. Construction and updates should be handled in the application layer when parent changes.
 }

--- a/src/Entities/HierarchicalEntityClosure.cs
+++ b/src/Entities/HierarchicalEntityClosure.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using AQ.Abstractions;
 
 namespace AQ.Entities;
@@ -7,13 +7,12 @@ namespace AQ.Entities;
 /// Closure table for hierarchical entities. Used for fast ancestor/descendant queries.
 /// Each row represents a path from Ancestor to Descendant with a given Depth.
 /// </summary>
+[NotMapped]
 public abstract class HierarchicalEntityClosure<T> : IHierarchicalEntityClosure where T : HierarchicalEntity<T>
 {
-    [Key]
     public Guid AncestorId { get; set; }
     public T Ancestor { get; set; } = default!;
 
-    [Key]
     public Guid DescendantId { get; set; }
     public T Descendant { get; set; } = default!;
     public int Depth { get; set; }


### PR DESCRIPTION
Remove the `Level` and `Depth` properties from the `IHierarchicalEntity`, `HierarchicalEntity`, `IHierarchicalEntityClosure`, and `HierarchicalEntityClosure` classes to simplify the hierarchy structure. Introduce new methods for checking ancestor and descendant relationships.